### PR TITLE
Typeinfogen CMake Integration

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1562,7 +1562,18 @@ if(MSVC)
 	#			   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/libs/curl/lib
     #               COMMENT "Compiling libcURL")
 		
-	add_dependencies(RBDoom3BFG idlib)
+	add_dependencies(RBDoom3BFG idlib typeinfogen)
+	
+	# call typeinfogen to generate neo/d3xp/gamesys/GameTypeInfo.h
+	add_custom_command(
+			TARGET RBDoom3BFG
+			PRE_BUILD
+			DEPENDS typeinfogen
+			COMMAND typeinfogen
+			WORKING_DIRECTORY ..
+			COMMENT "Generating neo/d3xp/gamesys/GameTypeInfo.h"
+			)
+	
 	target_link_libraries(RBDoom3BFG
 		idlib
 		${DirectX_LIBRARIES}

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8) # Eric: These are rookie numbers, you need to bump those numbers up.
+cmake_minimum_required(VERSION 3.2)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 project(RBDoom3BFG)
@@ -434,6 +434,7 @@ endif (RAPIDJSON_FOUND)
 
 	
 add_subdirectory(idlib)
+add_subdirectory(typeinfo)
 
 file(GLOB AAS_INCLUDES aas/*.h)
 file(GLOB AAS_SOURCES aas/*.cpp)

--- a/neo/idlib/CMakeLists.txt
+++ b/neo/idlib/CMakeLists.txt
@@ -92,12 +92,12 @@ if(MSVC)
         COMPILE_FLAGS "/Ycprecompiled.h"
         OBJECT_OUTPUTS "precompiled.pch"
         )
-        set_source_files_properties(
-            ${ID_PRECOMPILED_SOURCES}
-            PROPERTIES
-            COMPILE_FLAGS "/Yuprecompiled.h"
-            OBJECT_DEPENDS "precompiled.pch"
-            )
+	set_source_files_properties(
+		${ID_PRECOMPILED_SOURCES}
+		PROPERTIES
+		COMPILE_FLAGS "/Yuprecompiled.h"
+		OBJECT_DEPENDS "precompiled.pch"
+		)
 
     add_library(idlib ${ID_SOURCES_ALL} ${ID_INCLUDES_ALL})
 else()

--- a/neo/typeinfo/CMakeLists.txt
+++ b/neo/typeinfo/CMakeLists.txt
@@ -1,0 +1,141 @@
+
+add_definitions(-DTYPEINFOPROJECT -D__DOOM_DLL__)
+
+set(TP_INCLUDES
+	TypeInfoGen.h
+	)
+set(TP_SOURCES
+	EngineStub.cpp
+	TypeInfoGen.cpp
+	main.cpp
+	precompiled.cpp
+	)
+
+set(TP_FRAMEWORK_INCLUDES 
+	../framework/CmdSystem.h
+	../framework/CVarSystem.h
+	../framework/File.h
+	../framework/File_Manifest.h
+	../framework/File_Resource.h
+	../framework/FileSystem.h
+	../framework/Licensee.h
+	../idlib/precompiled.h
+	)
+set(TP_FRAMEWORK_SOURCES
+	../framework/CmdSystem.cpp
+	../framework/CVarSystem.cpp
+	../framework/File.cpp
+	../framework/File_Manifest.cpp
+	../framework/File_Resource.cpp
+	../framework/FileSystem.cpp
+	)
+	
+#if(NOT ZLIB_FOUND)
+	file(GLOB TP_ZLIB_INCLUDES ../libs/zlib/*.h)
+	file(GLOB TP_ZLIB_SOURCES ../libs/zlib/*.c)
+	list(APPEND TP_ZLIB_SOURCES ../libs/zlib/minizip/unzip.cpp)
+	list(APPEND TP_ZLIB_SOURCES ../libs/zlib/minizip/ioapi.c)
+#else (NOT ZLIB_FOUND)
+#	set(TP_ZLIB_INCLUDES "")
+#	set(TP_ZLIB_SOURCES "")
+#endif()
+
+
+set(TP_INCLUDES_ALL
+			${TP_INCLUDES}
+			${TP_FRAMEWORK_INCLUDES}
+			${TP_ZLIB_INCLUDES}
+			)
+			
+set(TP_SOURCES_ALL
+			${TP_SOURCES}
+			${TP_FRAMEWORK_SOURCES}
+			${TP_ZLIB_SOURCES}
+			)
+
+source_group("typeinfo" FILES ${TP_INCLUDES})
+source_group("typeinfo" FILES ${TP_SOURCES})
+source_group("framework" FILES ${TP_FRAMEWORK_INCLUDES})
+source_group("framework" FILES ${TP_FRAMEWORK_SOURCES})
+source_group("zlib" FILES ${TP_ZLIB_INCLUDES})
+source_group("zlib" FILES ${TP_ZLIB_SOURCES})
+
+set(TP_PRECOMPILED_SOURCES ${TP_SOURCES_ALL})
+
+include_directories(
+	.
+	../idlib
+	../libs/zlib
+	)
+
+if(MSVC)
+	list(REMOVE_ITEM TP_PRECOMPILED_SOURCES precompiled.cpp) 
+	list(REMOVE_ITEM TP_PRECOMPILED_SOURCES ${TP_ZLIB_SOURCES})
+
+	#foreach( src_file ${TP_PRECOMPILED_SOURCES} )
+	#	message(STATUS "-include precompiled.h for ${src_file}")
+	#endforeach()
+
+    #set_target_properties(idlib PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h")
+    set_source_files_properties(precompiled.cpp
+        PROPERTIES
+        COMPILE_FLAGS "/Ycprecompiled.h"
+        OBJECT_OUTPUTS "precompiled.pch"
+        )
+		
+	set_source_files_properties(
+		${TP_PRECOMPILED_SOURCES}
+		PROPERTIES
+		COMPILE_FLAGS "/Yuprecompiled.h"
+		OBJECT_DEPENDS "precompiled.pch"
+		)
+
+    add_executable(typeinfogen ${TP_SOURCES_ALL} ${TP_INCLUDES_ALL})
+	add_dependencies(typeinfogen idlib)
+	target_link_libraries(typeinfogen idlib winmm)
+	
+else()
+	if (USE_PRECOMPILED_HEADERS)
+	foreach( src_file ${TP_PRECOMPILED_SOURCES} )
+		#message(STATUS "-include precompiled.h for ${src_file}")
+		set_source_files_properties(
+			${src_file}
+			PROPERTIES
+			COMPILE_FLAGS "-include ${CMAKE_CURRENT_SOURCE_DIR}/precompiled.h"
+			)
+	endforeach()
+	endif()
+
+	include_directories(.)
+	
+	if (USE_PRECOMPILED_HEADERS)
+	# precompiled magic for GCC/clang, adapted from https://gist.github.com/573926
+	STRING(TOUPPER "CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}" _flags_var_name)
+	SET(_compiler_FLAGS "${${_flags_var_name}} -std=c++${CMAKE_CXX_STANDARD}")
+	GET_DIRECTORY_PROPERTY(_directory_flags INCLUDE_DIRECTORIES)
+	FOREACH(item ${_directory_flags})
+		LIST(APPEND _compiler_FLAGS " -I${item}")
+	ENDFOREACH(item)
+	endif()
+
+	GET_DIRECTORY_PROPERTY(_directory_flags DEFINITIONS)
+	LIST(APPEND _compiler_FLAGS ${_directory_flags})
+	
+	SEPARATE_ARGUMENTS(_compiler_FLAGS)
+	
+	if (USE_PRECOMPILED_HEADERS)
+	add_custom_target(precomp_header_typeinfo ALL
+	                  COMMAND ${CMAKE_CXX_COMPILER} ${_compiler_FLAGS} -x c++-header precompiled.h -o precompiled.h.gch
+	                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	                  COMMENT "Creating idlib/precompiled.h.gch for idlib"
+	                  )
+	endif()
+	
+	add_executable(typeinfo ${TP_SOURCES_ALL} ${TP_INCLUDES_ALL})
+	if (USE_PRECOMPILED_HEADERS)
+	add_dependencies(typeinfo precomp_header_typeinfo)
+	endif()
+	
+endif()
+	
+

--- a/neo/typeinfo/precompiled.cpp
+++ b/neo/typeinfo/precompiled.cpp
@@ -1,0 +1,29 @@
+/*
+===========================================================================
+
+Doom 3 BFG Edition GPL Source Code
+Copyright (C) 1993-2012 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Doom 3 BFG Edition GPL Source Code ("Doom 3 BFG Edition Source Code").
+
+Doom 3 BFG Edition Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Doom 3 BFG Edition Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Doom 3 BFG Edition Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Doom 3 BFG Edition Source Code is also subject to certain additional terms. You should have received a copy of these additional terms immediately following the terms and conditions of the GNU General Public License which accompanied the Doom 3 BFG Edition Source Code.  If not, please request a copy in writing from id Software at the address below.
+
+If you have questions concerning this license or the applicable additional terms, you may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "precompiled.h"


### PR DESCRIPTION
This builds typeinfogen.exe and calls it to to generate neo/d3xp/gamesys/GameTypeInfo.h/cpp before RBDoom3BFG.exe gets compiled.